### PR TITLE
Channel order update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Introduced `Typeguard` for runtime type validation, which can be configureg on/off via environment variables.
+- Introduced `Typeguard` for runtime type validation, which can be configured on/off via environment variables.
+- `DimensionOrder` enum class for controlling the order of dimensions at IO boundaries.
 
 ### Fixed
 
@@ -13,6 +14,11 @@
 ### Changed
 
 - References to `.validation.type_checks.validate_all` removed in favor of `Typeguard` decorator checks.
+- In `losses.py` and `ICRFModelBase` and its subclasses, changed the internal channel ordering of the data from (n_points, channels) dimension order to (channels, n_points).
+
+### Removed
+
+- Removed Protocol based Transforms, preferring BaseTransform for type hints and as base for writing Transform classes.
 
 ## [0.2.0]
 

--- a/clair_torch/common/__init__.py
+++ b/clair_torch/common/__init__.py
@@ -11,7 +11,7 @@ from .enums import InterpMode, MissingStdMode, ChannelOrder, VarianceMode
 from .file_settings import FileSettings, PairedFileSettings, FrameSettings, PairedFrameSettings, file_settings_constructor, group_frame_settings_by_attributes
 from .general_functions import weighted_mean_and_std, flat_field_mean, flatfield_correction, get_valid_exposure_pairs, get_pairwise_valid_pixel_mask, cv_to_torch, torch_to_cv, normalize_tensor, clamp_along_dims, conditional_gaussian_blur, cli_parse_args_from_config
 from .statistics import WBOMean, WBOMeanVar
-from .transforms import Transform, CvToTorch, TorchToCv, CastTo, ClampAlongDims, Normalize, StridedDownscale
+from .transforms import BaseTransform, CvToTorch, TorchToCv, CastTo, ClampAlongDims, Normalize, StridedDownscale
 
 __all__ = [
     "BaseFileSettings",
@@ -30,6 +30,6 @@ __all__ = [
 
     "WBOMean", "WBOMeanVar",
 
-    "Transform", "CvToTorch", "TorchToCv", "CastTo", "ClampAlongDims", "Normalize",
+    "BaseTransform", "CvToTorch", "TorchToCv", "CastTo", "ClampAlongDims", "Normalize",
     "StridedDownscale"
 ]

--- a/clair_torch/common/base.py
+++ b/clair_torch/common/base.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 
 from typeguard import typechecked
 
-from clair_torch.common.transforms import Transform
+from clair_torch.common.transforms import BaseTransform
 from clair_torch.validation.io_checks import validate_input_file_path, is_potentially_valid_file_path
 
 
@@ -36,7 +36,7 @@ class BaseFileSettings(ABC):
     @typechecked
     def __init__(self, input_path: str | Path, output_path: Optional[str | Path] = None,
                  default_output_root: Optional[str | Path] = None,
-                 cpu_transforms: Optional[Transform | Sequence[Transform]] = None):
+                 cpu_transforms: Optional[BaseTransform | Sequence[BaseTransform]] = None):
         """
         Initializes the instance with the given paths. Output and default roots are optional and defer to a default
         output root if None is given. output_path overrides any possible default_output_root values. Upon loading data
@@ -69,7 +69,7 @@ class BaseFileSettings(ABC):
         if cpu_transforms is not None and not isinstance(cpu_transforms, (list, tuple)):
             cpu_transforms = [cpu_transforms]
 
-        if cpu_transforms is not None and not all(isinstance(t, Transform) for t in cpu_transforms):
+        if cpu_transforms is not None and not all(isinstance(t, BaseTransform) for t in cpu_transforms):
             raise TypeError(f"At least one item in transforms is of incorrect type: {cpu_transforms}")
 
         self.cpu_transforms = cpu_transforms
@@ -93,7 +93,7 @@ class BaseFileSettings(ABC):
         pass
 
     @abstractmethod
-    def get_transforms(self) -> List[Transform] | None:
+    def get_transforms(self) -> List[BaseTransform] | None:
         """
         Method for getting the possible Transform operations from a FileSettings class.
         Returns:

--- a/clair_torch/common/data_io.py
+++ b/clair_torch/common/data_io.py
@@ -13,7 +13,7 @@ import torch
 import numpy as np
 import cv2 as cv
 
-from clair_torch.common.transforms import Transform
+from clair_torch.common.transforms import BaseTransform
 from clair_torch.common.general_functions import cv_to_torch, normalize_container
 from clair_torch.common.enums import ChannelOrder
 from clair_torch.validation.io_checks import validate_input_file_path, is_potentially_valid_file_path
@@ -105,7 +105,8 @@ def load_principal_components(file_paths: list[str | Path]) -> torch.Tensor:
 
 
 @typechecked
-def load_image(file_path: str | Path, transforms: Optional[Transform | Iterable[Transform]] = None) -> torch.Tensor:
+def load_image(file_path: str | Path,
+               transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None) -> torch.Tensor:
     """
     Generic function to load a single image from the given path. Allows also the definition of transformations to be
     performed on the image before returning it upstream.
@@ -136,8 +137,9 @@ def load_image(file_path: str | Path, transforms: Optional[Transform | Iterable[
 
 
 @typechecked
-def load_video_frames_generator(file_path: str | Path, transforms: Optional[Transform | Iterable[Transform]] = None) \
-        -> torch.Tensor | None:
+def load_video_frames_generator(file_path: str | Path,
+                                transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None) \
+                                -> Generator[torch.Tensor | None, None, None]:
     """
     Function for loading frames from a video file through a generator.
     Args:

--- a/clair_torch/common/data_io.py
+++ b/clair_torch/common/data_io.py
@@ -5,7 +5,7 @@ other functions, classes etc. in this project.
 """
 
 from pathlib import Path
-from typing import Optional, Iterable, Sequence
+from typing import Optional, Iterable, Sequence, Generator
 import yaml
 
 from typeguard import typechecked
@@ -15,18 +15,20 @@ import cv2 as cv
 
 from clair_torch.common.transforms import BaseTransform
 from clair_torch.common.general_functions import cv_to_torch, normalize_container
-from clair_torch.common.enums import ChannelOrder
+from clair_torch.common.enums import ChannelOrder, DimensionOrder
 from clair_torch.validation.io_checks import validate_input_file_path, is_potentially_valid_file_path
 
 
 @typechecked
-def load_icrf_txt(path: str | Path, source_channel_order: ChannelOrder = ChannelOrder.BGR) -> torch.Tensor:
+def load_icrf_txt(path: str | Path, source_channel_order: ChannelOrder = ChannelOrder.BGR,
+                  source_dimension_order: DimensionOrder = DimensionOrder.BSC) -> torch.Tensor:
     """
     Utility function for loading an inverse camera response function from a .txt file. Expects a 2D NumPy array
     with shape (N, C), with N representing the number of datapoints
     Args:
         path: path to the text file containing the ICRF data.
         source_channel_order: the order in which the channels are expected to be in the file.
+        source_dimension_order: the order in which the dimensions are expected to be in the file.
 
     Returns:
         torch.Tensor representing the ICRF.
@@ -37,32 +39,37 @@ def load_icrf_txt(path: str | Path, source_channel_order: ChannelOrder = Channel
     validate_input_file_path(path, suffix=".txt")
 
     try:
-        data = np.loadtxt(path)  # shape: (256, 3), BGR order
+        data = torch.from_numpy(np.loadtxt(path)).float()  # shape: (256, 3), BGR order
     except Exception as e:
         raise IOError(f'Failed to load NumPy array from {path}: {e}')
 
+    if source_dimension_order == DimensionOrder.BCS:
+        pass
+    elif source_dimension_order == DimensionOrder.BSC:
+        data = torch.transpose(data, 0, 1)
+
     # No change for any and RGB ordering.
     if source_channel_order == ChannelOrder.ANY or source_channel_order == ChannelOrder.RGB:
-        data_rgb = data
+        pass
     # Reverse BGR order into RGB order.
     elif source_channel_order == ChannelOrder.BGR:
-        data_rgb = data[:, ::-1].copy()  # shape: (256, 3)
+        data = data[[2, 1, 0], :]
     # Raise value error for unknown channel ordering.
     else:
         raise ValueError(f"Unknown channel order {source_channel_order}:")
 
-    # Convert to PyTorch tensor
-    icrf_tensor = torch.from_numpy(data_rgb).float()
-
-    return icrf_tensor
+    return data
 
 
 @typechecked
-def save_icrf_txt(icrf: torch.Tensor, path: str | Path) -> None:
+def save_icrf_txt(icrf: torch.Tensor, path: str | Path, target_channel_order: ChannelOrder = ChannelOrder.BGR,
+                  target_dimension_order: DimensionOrder = DimensionOrder.BSC) -> None:
     """
     Utility function to save an ICRF into a .txt file of the given filepath.
     Args:
         icrf: the ICRF tensor.
+        target_channel_order: the order in which the channels are to be in the saved data.
+        target_dimension_order: the order in which the dimensions are to be in the saved data.
         path: the filepath where to save the file.
 
     Returns:
@@ -72,8 +79,18 @@ def save_icrf_txt(icrf: torch.Tensor, path: str | Path) -> None:
     if not is_potentially_valid_file_path(path):
         raise IOError(f"Invalid path for your OS: {path}")
 
-    data = icrf.detach().cpu().numpy()
-    data = data[:, ::-1]
+    data = icrf.detach().cpu()
+    if target_channel_order == ChannelOrder.RGB:
+        pass
+    elif target_channel_order == ChannelOrder.BGR:
+        data = data[[2, 1, 0], :]
+
+    if target_dimension_order == DimensionOrder.BCS:
+        pass
+    elif target_dimension_order == DimensionOrder.BSC:
+        data = torch.transpose(data, 0, 1)
+
+    data = data.numpy()
 
     try:
         np.savetxt(path, data)
@@ -86,7 +103,7 @@ def save_icrf_txt(icrf: torch.Tensor, path: str | Path) -> None:
 @typechecked
 def load_principal_components(file_paths: list[str | Path]) -> torch.Tensor:
     """
-    Loads principal component data from text files, one per color channel. The files in the input paths should be
+    Loads principal component data from text files, one file per color channel. The files in the input paths should be
     ordered in the desired channel order. E.g. for RGB images it should point to the red, green and blue files in order.
 
     Args:
@@ -124,10 +141,11 @@ def load_image(file_path: str | Path,
 
     try:
         image = cv.imread(str(file_path), cv.IMREAD_UNCHANGED)
-        image = torch.from_numpy(image)
-        image = cv_to_torch(image)
     except Exception as e:
         raise IOError(f"Failed to load NumPy array from {file_path}: {e}")
+
+    image = torch.from_numpy(image)
+    image = cv_to_torch(image)
 
     if transforms:
         for transform in transforms:
@@ -147,7 +165,7 @@ def load_video_frames_generator(file_path: str | Path,
         transforms: optional list of transform operations to perform on each frame before yielding them.
 
     Returns:
-
+        Generator, which yields torch.Tensors.
     """
     validate_input_file_path(file_path, suffix=None)
 
@@ -170,7 +188,7 @@ def load_video_frames_generator(file_path: str | Path,
     cap.release()
 
 
-def _get_frame_count(file_path: str | Path):
+def _get_frame_count(file_path: str | Path) -> int:
     """
     Utility function to get the number of frames in a video file.
     Args:
@@ -221,7 +239,8 @@ def save_image(tensor: torch.Tensor, image_save_path: str | Path, dtype: np.dtyp
 
 
 @typechecked
-def _get_file_input_paths_by_pattern(search_root: str | Path, pattern: str = f"*", recursive_search: bool = False) -> list[Path]:
+def _get_file_input_paths_by_pattern(search_root: str | Path, pattern: str = f"*", recursive_search: bool = False)\
+        -> list[Path]:
     """
     Utility function to collect all filepaths of the given file suffix. Optionally allows recursive search of the
     subdirectories of the given search_root.

--- a/clair_torch/common/enums.py
+++ b/clair_torch/common/enums.py
@@ -53,6 +53,14 @@ class ChannelOrder(Enum):
     ANY = auto()
 
 
+class DimensionOrder(Enum):
+    """
+    Manges the ordering of data dimensions.
+    """
+    BCS = auto()    # Batch, Channel, Spatial - Common for PyTorch and ML packages.
+    BSC = auto()    # Batch, Spatial, Channel - common for OpenCV
+
+
 class VarianceMode(Enum):
     """
     Manages how the variance is computed in the WBOMeanVar class.

--- a/clair_torch/common/file_settings.py
+++ b/clair_torch/common/file_settings.py
@@ -9,7 +9,7 @@ from typing import Iterable, Optional, Tuple, List, Sequence, Type, Callable
 from typeguard import typechecked
 
 from clair_torch.metadata.imaging_metadata import ImagingMetadata, BaseMetadata
-from clair_torch.common.transforms import Transform
+from clair_torch.common.transforms import BaseTransform
 from clair_torch.common.base import BaseFileSettings
 from clair_torch.common.data_io import _get_file_input_paths_by_pattern, _pair_main_and_std_files
 
@@ -27,7 +27,7 @@ class FileSettings(BaseFileSettings):
     @typechecked
     def __init__(self, input_path: str | Path, output_path: Optional[str | Path] = None,
                  default_output_root: Optional[str | Path] = None,
-                 cpu_transforms: Optional[Transform | Iterable[Transform]] = None):
+                 cpu_transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None):
         """
         Initializes the instance with the given paths. Output and default roots are optional and defer to a default
         output root if None is given. output_path overrides any possible default_output_root values. Upon loading data
@@ -67,7 +67,7 @@ class FileSettings(BaseFileSettings):
 
         return std_output_path
 
-    def get_transforms(self) -> List[Transform] | None:
+    def get_transforms(self) -> List[BaseTransform] | None:
         """
         Method for getting the possible Transform operations to be performed on the data upon reading it.
         Returns:
@@ -114,7 +114,7 @@ class FrameSettings(FileSettings):
     @typechecked
     def __init__(self, input_path: str | Path, output_path: Optional[str | Path] = None,
                  default_output_root: Optional[str | Path] = None,
-                 cpu_transforms: Optional[Transform | Iterable[Transform]] = None,
+                 cpu_transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None,
                  metadata_cls: Type[BaseMetadata] = ImagingMetadata,
                  *metadata_args, **metadata_kwargs):
         super().__init__(input_path, output_path, default_output_root, cpu_transforms)
@@ -184,8 +184,8 @@ class PairedFileSettings(FileSettings):
                  val_output_path: Optional[str | Path] = None,
                  std_output_path: Optional[str | Path] = None,
                  default_output_root: Optional[str | Path] = None,
-                 val_cpu_transforms: Optional[Transform | Iterable[Transform]] = None,
-                 std_cpu_transforms: Optional[Transform | Iterable[Transform]] = None):
+                 val_cpu_transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None,
+                 std_cpu_transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None):
         """
         Initializes a PairedFileSettings object with the given paths. The class both inherits from FileSettings and is
         a composition of two instances of FileSettings. Referring to self.val_input_path is the same as referring to
@@ -240,7 +240,7 @@ class PairedFileSettings(FileSettings):
         """
         return self.val_settings.get_output_paths(), self.std_settings.get_output_paths()
 
-    def get_transforms(self) -> Tuple[List[Transform], List[Transform]]:
+    def get_transforms(self) -> Tuple[List[BaseTransform], List[BaseTransform]]:
         """
         Method for getting the transformation operations. Overrides the inherited method by deferring the process for
         the two encapsulated instances.
@@ -268,8 +268,8 @@ class PairedFrameSettings(PairedFileSettings):
     def __init__(self, val_input_path: str | Path, std_input_path: Optional[str | Path] = None,
                  val_output_path: Optional[str | Path] = None, std_output_path: Optional[str | Path] = None,
                  default_output_root: Optional[str | Path] = None,
-                 val_cpu_transforms: Optional[Transform | Iterable[Transform]] = None,
-                 std_cpu_transforms: Optional[Transform | Iterable[Transform]] = None,
+                 val_cpu_transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None,
+                 std_cpu_transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None,
                  parse_std_meta: bool = False, metadata_cls: Type[BaseMetadata] = ImagingMetadata,
                  *metadata_args, **metadata_kwargs):
         """
@@ -355,8 +355,8 @@ def file_settings_constructor(
     file_pattern: str,
     recursive: bool = False,
     default_output_root: Optional[Path] = None,
-    val_cpu_transforms: Optional[Transform | Iterable[Transform]] = None,
-    std_cpu_transforms: Optional[Transform | Iterable[Transform]] = None,
+    val_cpu_transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None,
+    std_cpu_transforms: Optional[BaseTransform | Iterable[BaseTransform]] = None,
     metadata_cls: Optional[Type[BaseMetadata]] = None,
     strict_exclusive: bool = True,
     *metadata_args,

--- a/clair_torch/common/transforms.py
+++ b/clair_torch/common/transforms.py
@@ -2,7 +2,7 @@
 Module for transforms to be used with PyTorch tensors. Main use is for chaining required operations on in __getitem__
 of ImageDataset class.
 """
-from typing import Protocol, Optional, Any, Type, runtime_checkable, Iterable
+from typing import Optional, Any, Type, Iterable
 from abc import ABC, abstractmethod
 
 import torch
@@ -62,16 +62,6 @@ class BaseTransform(ABC):
             A new instance of this class.
         """
         return cls(**cfg)
-
-
-@runtime_checkable
-class Transform(Protocol):
-    """
-    Class stub for typing purposes. Used to indicate that a transform such as the ones in this module is required.
-    """
-
-    def __call__(self, x: torch.Tensor) -> torch.Tensor:
-        ...
 
 
 @_register_transform

--- a/clair_torch/inference/linearization.py
+++ b/clair_torch/inference/linearization.py
@@ -7,7 +7,8 @@ import torch
 from torch.utils.data import DataLoader
 from typeguard import typechecked
 
-from clair_torch.common import general_functions as gf, transforms as tr
+from clair_torch.common import general_functions as gf
+from clair_torch.common.transforms import BaseTransform
 from clair_torch.datasets.image_dataset import FlatFieldArtefactMapDataset, DarkFieldArtefactMapDataset, ImageMapDataset
 from clair_torch.models.base import ICRFModelBase
 
@@ -18,7 +19,7 @@ def linearize_dataset_generator(
         device: str | torch.device,
         icrf_model: ICRFModelBase,
         flatfield_dataset: Optional[FlatFieldArtefactMapDataset] = None,
-        gpu_transforms: Optional[tr.Transform | Sequence[tr.Transform]] = None,
+        gpu_transforms: Optional[BaseTransform | Sequence[BaseTransform]] = None,
         dark_field_dataset: Optional[DarkFieldArtefactMapDataset] = None
 ) -> Generator[tuple[torch.Tensor, torch.Tensor, dict], None, None]:
     """

--- a/clair_torch/models/icrf_model.py
+++ b/clair_torch/models/icrf_model.py
@@ -1,3 +1,6 @@
+"""
+Module for the concrete implementations of the ICRFModelBase class
+"""
 from typing import Optional
 
 import torch
@@ -9,10 +12,36 @@ from clair_torch.common.enums import InterpMode
 
 
 class ICRFModelPCA(ICRFModelBase):
+    """
+    ICRF model class that utilizes a set of principal components for the optimization process. For each principal
+    component a single scalar optimization parameter is utilized, e.g. for 5 components there is a total of 5 parameters
+    to optimize in the model. The shape of the given principal components is used to determine the number of datapoints,
+    number of components and number of channels. In addition to these an exponent for the linear range [0, 1] is used
+    as a parameter for each channel.
+
+    Attributes:
+    -----------
+    Inherits attributes from ICRFModelBase
+
+    p: nn.ParameterList
+        a list of nn parameters representing the exponent of the base curve. One element for each channel.
+    coefficients: nn.ParameterList
+        a list of nn parameters representing the PCA parameters, for each channel a number equal to the number of
+            components.
+    """
     @typechecked
     def __init__(self, pca_basis: torch.Tensor, interpolation_mode: InterpMode = InterpMode.LINEAR,
                  initial_power: float = 2.5, icrf: Optional[torch.Tensor] = None) -> None:
-
+        """
+        Initializes a ICRFModelPCA instance. The pca_basis is used to determine the shape of the actual ICRF.
+        Args:
+            pca_basis: a torch.Tensor representing the principal components. The shape is expected to be
+                (n_points, num_components, channels).
+            interpolation_mode: a InterpMode determining how the ICRF is used in a forward call.
+            initial_power: a guess at the initial form of the ICRF curve, represented by raising the linear range [0, 1]
+                to this power.
+            icrf: an optional initial form of the ICRF curves, overrides n_points and channels.
+        """
         n_points, num_components, channels = pca_basis.shape
 
         super().__init__(n_points, channels, interpolation_mode, initial_power, icrf)
@@ -26,9 +55,15 @@ class ICRFModelPCA(ICRFModelBase):
         self.register_buffer("pca_basis", pca_basis)
         self.register_buffer("x_values", torch.linspace(0, 1, n_points))  # (L,)
 
-        self._fig = None
-
     def channel_params(self, c: int) -> list[nn.Parameter]:
+        """
+        Main method for accessing the optimization parameters of the model.
+        Args:
+            c: channel index.
+
+        Returns:
+            A list of nn.Parameters.
+        """
         return [self.p[c], self.coefficients[c]]
 
     def update_icrf(self):
@@ -52,6 +87,17 @@ class ICRFModelPCA(ICRFModelBase):
 
 
 class ICRFModelDirect(ICRFModelBase):
+    """
+    An ICRF model class that utilizes the datapoints directly as optimization parameters. Total number of parameters is
+    therefore n_points * channels.
+
+    Attributes:
+    ----------
+    Inherits attributes from ICRFModelBase.
+
+    direct_params: nn.ParameterList
+        a list of nn parameters, each parameter corresponds to an actual datapoint in the ICRF curve.
+    """
     @typechecked
     def __init__(self, n_points: Optional[int] = 256, channels: Optional[int] = 3,
                  interpolation_mode: InterpMode = InterpMode.LINEAR, initial_power: float = 2.5,
@@ -59,19 +105,26 @@ class ICRFModelDirect(ICRFModelBase):
 
         super().__init__(n_points, channels, interpolation_mode, initial_power, icrf)
 
-        # Override PCA parameters with direct per-channel parameters
         self.direct_params = nn.ParameterList([
             nn.Parameter(torch.linspace(0, 1, n_points) ** initial_power) for _ in range(channels)
         ])
 
     def channel_params(self, c: int):
+        """
+        Main method for accessing the optimization parameters of the model.
+        Args:
+            c: channel index.
+
+        Returns:
+            A list of nn.Parameters.
+        """
         return [self.direct_params[c]]
 
     def update_icrf(self):
         """
         Directly stack the per-channel parameters to form the ICRF.
         """
-        self._icrf = torch.stack([p for p in self.direct_params], dim=1)  # shape: (L, C)
+        self._icrf = torch.stack([p for p in self.direct_params], dim=0)  # shape: (L, C)
 
 
 if __name__ == "__main__":

--- a/clair_torch/visualization/plotting.py
+++ b/clair_torch/visualization/plotting.py
@@ -90,9 +90,9 @@ def plot_data_and_diff(x_datapoints: np.ndarray, datapoints: np.ndarray, datapoi
     fig, axs = plt.subplots(1, 2, figsize=(12, 5))
     lines_curve, lines_deriv = [], []
 
-    for c in range(datapoints.shape[1]):
-        (line,) = axs[0].plot(x_datapoints, datapoints[:, c], label=f"Channel {c}")
-        (dline,) = axs[1].plot(x_datapoints[:-1], datapoints_diff[:, c], label=f"Channel {c}")
+    for c in range(datapoints.shape[0]):
+        (line,) = axs[0].plot(x_datapoints, datapoints[c, :], label=f"Channel {c}")
+        (dline,) = axs[1].plot(x_datapoints[:-1], datapoints_diff[c, :], label=f"Channel {c}")
         lines_curve.append(line)
         lines_deriv.append(dline)
 


### PR DESCRIPTION
Flipped dimension ordering in ICRF model classes and loss functions from (datapoints, channels) to (channels, datapoints), matching PyTorch convention. Added some documentation, removed Protocol based Transform and deferred typehinting to BaseTransform.